### PR TITLE
Meetings and Experiences cards and lists are transformed into material ui components

### DIFF
--- a/src/components/ExperiencesComponents/ExperienceCard.js
+++ b/src/components/ExperiencesComponents/ExperienceCard.js
@@ -2,7 +2,6 @@ import React from "react";
 import ExperienceForm from "./ExperienceForm";
 import { deleteExperience } from "../../actions";
 import { connect } from "react-redux";
-import { Button, Modal, ModalHeader, ModalBody, ModalFooter } from "reactstrap";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import ExpansionPanel from "@material-ui/core/ExpansionPanel";
@@ -10,22 +9,27 @@ import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
 import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
 import Typography from "@material-ui/core/Typography";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
 
 const styles = theme => ({
-    root: {
-      width: '100%',
-    },
-    heading: {
-      fontSize: theme.typography.pxToRem(15),
-      fontWeight: theme.typography.fontWeightRegular,
-    },
-  });
+  root: {
+    width: "100%"
+  },
+  heading: {
+    fontSize: theme.typography.pxToRem(15),
+    fontWeight: theme.typography.fontWeightRegular
+  }
+});
 
 class ExperienceCard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      modal: false
+      modal: false,
+      open: false
     };
 
     this.toggle = this.toggle.bind(this);
@@ -36,6 +40,15 @@ class ExperienceCard extends React.Component {
       modal: !prevState.modal
     }));
   }
+
+  handleClickOpen = () => {
+    this.setState({ open: true });
+  };
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
+
   render() {
     const externalCloseBtn = (
       <button
@@ -46,37 +59,49 @@ class ExperienceCard extends React.Component {
         &times;
       </button>
     );
-    
+
     return (
       <ExpansionPanel>
-        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />} >
+        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
           <h4>{this.props.name}</h4>
         </ExpansionPanelSummary>
         <ExpansionPanelDetails>
           <Button
+            variant="outlined"
+            color="primary"
             onClick={() => {
               this.props.deleteExperience(this.props.id);
             }}
           >
-            delete
+            Delete
           </Button>
-          <Button color="warning" onClick={this.toggle}>
+
+          <Button
+            variant="outlined"
+            color="primary"
+            onClick={this.handleClickOpen}
+          >
             Edit
           </Button>
-          <Modal
-            isOpen={this.state.modal}
-            toggle={this.toggle}
-            className={this.props.className}
-            external={externalCloseBtn}
+
+          <Dialog
+            open={this.state.open}
+            onClose={this.handleClose}
+            aria-labelledby="form-dialog-title"
           >
-            <ModalBody>
+            <DialogContent>
               <ExperienceForm
                 canEdit={true}
                 id={this.props.id}
                 name={this.props.name}
               />
-            </ModalBody>
-          </Modal>
+            </DialogContent>
+            <DialogActions>
+              <Button onClick={this.handleClose} color="primary">
+                Cancel
+              </Button>
+            </DialogActions>
+          </Dialog>
         </ExpansionPanelDetails>
       </ExpansionPanel>
     );

--- a/src/components/ExperiencesComponents/ExperienceCard.js
+++ b/src/components/ExperiencesComponents/ExperienceCard.js
@@ -28,18 +28,12 @@ class ExperienceCard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      modal: false,
       open: false
     };
 
-    this.toggle = this.toggle.bind(this);
   }
 
-  toggle() {
-    this.setState(prevState => ({
-      modal: !prevState.modal
-    }));
-  }
+
 
   handleClickOpen = () => {
     this.setState({ open: true });
@@ -50,15 +44,7 @@ class ExperienceCard extends React.Component {
   };
 
   render() {
-    const externalCloseBtn = (
-      <button
-        className="close"
-        style={{ position: "absolute", top: "15px", right: "15px" }}
-        onClick={this.toggle}
-      >
-        &times;
-      </button>
-    );
+
 
     return (
       <ExpansionPanel>

--- a/src/components/ExperiencesComponents/ExperienceList.js
+++ b/src/components/ExperiencesComponents/ExperienceList.js
@@ -5,22 +5,17 @@ import {
   getSpecificExperience,
   updateExperience
 } from "../../actions";
-import {  Modal, ModalBody } from "reactstrap";
 import ExperienceForm from "./ExperienceForm";
 import ExeperienceCard from "./ExperienceCard";
 import Button from '@material-ui/core/Button';
-import TextField from '@material-ui/core/TextField';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
-import DialogContentText from '@material-ui/core/DialogContentText';
-import DialogTitle from '@material-ui/core/DialogTitle';
 
 class ExperienceList extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      modal: false,
       isLoaded: false,
       open: false
     };

--- a/src/components/ExperiencesComponents/ExperienceList.js
+++ b/src/components/ExperiencesComponents/ExperienceList.js
@@ -5,16 +5,24 @@ import {
   getSpecificExperience,
   updateExperience
 } from "../../actions";
-import { Button, Modal, ModalBody } from "reactstrap";
+import {  Modal, ModalBody } from "reactstrap";
 import ExperienceForm from "./ExperienceForm";
 import ExeperienceCard from "./ExperienceCard";
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogTitle from '@material-ui/core/DialogTitle';
 
 class ExperienceList extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
       modal: false,
-      isLoaded: false
+      isLoaded: false,
+      open: false
     };
 
     this.toggle = this.toggle.bind(this);
@@ -29,6 +37,15 @@ class ExperienceList extends React.Component {
     await this.props.getExperiences();
     this.setState({ isLoaded: true });
   }
+
+  handleClickOpen = () => {
+    this.setState({ open: true });
+  };
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
+
   render() {
     const externalCloseBtn = (
       <button
@@ -46,9 +63,25 @@ class ExperienceList extends React.Component {
     return (
       <div>
         <h1>Experiences</h1>
-        <Button color="primary" onClick={this.toggle}>
+        <Button variant="outlined" color="primary" onClick={this.handleClickOpen}>
           Create New Experience
         </Button>
+        <Dialog
+          open={this.state.open}
+          onClose={this.handleClose}
+          aria-labelledby="form-dialog-title"
+        >
+          <DialogContent>
+          <ExperienceForm canEdit={false} />
+
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleClose} color="primary">
+              Cancel
+            </Button>
+          </DialogActions>
+        </Dialog>
+
         {this.state.isLoaded ? (
           nonDeleted.map(experience => {
             return (
@@ -62,18 +95,6 @@ class ExperienceList extends React.Component {
         ) : (
           <h2>Loading</h2>
         )}
-
-
-        <Modal
-          isOpen={this.state.modal}
-          toggle={this.toggle}
-          className={this.props.className}
-          external={externalCloseBtn}
-        >
-          <ModalBody>
-            <ExperienceForm canEdit={false} />
-          </ModalBody>
-        </Modal>
       </div>
     );
   }

--- a/src/components/ExperiencesComponents/ExperienceList.js
+++ b/src/components/ExperiencesComponents/ExperienceList.js
@@ -7,10 +7,10 @@ import {
 } from "../../actions";
 import ExperienceForm from "./ExperienceForm";
 import ExeperienceCard from "./ExperienceCard";
-import Button from '@material-ui/core/Button';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
 
 class ExperienceList extends React.Component {
   constructor(props) {
@@ -48,7 +48,11 @@ class ExperienceList extends React.Component {
     return (
       <div>
         <h1>Experiences</h1>
-        <Button variant="outlined" color="primary" onClick={this.handleClickOpen}>
+        <Button
+          variant="outlined"
+          color="primary"
+          onClick={this.handleClickOpen}
+        >
           Create New Experience
         </Button>
         <Dialog
@@ -57,8 +61,7 @@ class ExperienceList extends React.Component {
           aria-labelledby="form-dialog-title"
         >
           <DialogContent>
-          <ExperienceForm canEdit={false} />
-
+            <ExperienceForm canEdit={false} />
           </DialogContent>
           <DialogActions>
             <Button onClick={this.handleClose} color="primary">

--- a/src/components/ExperiencesComponents/ExperienceList.js
+++ b/src/components/ExperiencesComponents/ExperienceList.js
@@ -42,16 +42,6 @@ class ExperienceList extends React.Component {
   };
 
   render() {
-    const externalCloseBtn = (
-      <button
-        className="close"
-        style={{ position: "absolute", top: "15px", right: "15px" }}
-        onClick={this.toggle}
-      >
-        &times;
-      </button>
-    );
-
     const nonDeleted = this.props.experiences.filter(experience => {
       return experience.deleted === false;
     });

--- a/src/components/MeetingsComponents/MeetingCard.js
+++ b/src/components/MeetingsComponents/MeetingCard.js
@@ -1,8 +1,8 @@
-import React from 'react';
-import MeetingsForm from './MeetingsForm.js';
-import { connect } from 'react-redux';
-import { Button, Modal, ModalBody } from 'reactstrap';
-import { deleteMeeting } from '../../actions';
+import React from "react";
+import MeetingsForm from "./MeetingsForm.js";
+import { connect } from "react-redux";
+import { Modal, ModalBody } from "reactstrap";
+import { deleteMeeting } from "../../actions";
 import PropTypes from "prop-types";
 import { withStyles } from "@material-ui/core/styles";
 import ExpansionPanel from "@material-ui/core/ExpansionPanel";
@@ -10,88 +10,107 @@ import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
 import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
 import Typography from "@material-ui/core/Typography";
 import ExpandMoreIcon from "@material-ui/icons/ExpandMore";
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
 
 const styles = theme => ({
-    root: {
-      width: '100%',
-    },
-    heading: {
-      fontSize: theme.typography.pxToRem(15),
-      fontWeight: theme.typography.fontWeightRegular,
-    },
-  });
+  root: {
+    width: "100%"
+  },
+  heading: {
+    fontSize: theme.typography.pxToRem(15),
+    fontWeight: theme.typography.fontWeightRegular
+  }
+});
 
 class MeetingCard extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {
-            modal: false
-        };
+  constructor(props) {
+    super(props);
+    this.state = {
+      open: false
+    };
+  }
 
-        this.toggle = this.toggle.bind(this);
-    }
+  handleClickOpen = () => {
+    this.setState({ open: true });
+  };
 
-    toggle() {
-        this.setState((prevState) => ({
-            modal: !prevState.modal
-        }));
-    }
+  handleClose = () => {
+    this.setState({ open: false });
+  };
 
-    render() {
-        const externalCloseBtn = (
-            <button
-                className='close'
-                style={{ position: 'absolute', top: '15px', right: '15px' }}
-                onClick={this.toggle}
+  render() {
+    const externalCloseBtn = (
+      <button
+        className="close"
+        style={{ position: "absolute", top: "15px", right: "15px" }}
+        onClick={this.toggle}
+      >
+        &times;
+      </button>
+    );
+    return (
+      <div>
+        <ExpansionPanel>
+          <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
+            <h3>{this.props.content}</h3>
+          </ExpansionPanelSummary>
+          <ExpansionPanelDetails>
+            <h4>Match_id:{this.props.match_id}</h4>
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={() => {
+                this.props.deleteMeeting(this.props.id);
+              }}
             >
-                &times;
-            </button>
-        );
-        return (
-            <div>
-                <ExpansionPanel>
-                    <ExpansionPanelSummary expandIcon={<ExpandMoreIcon />}>
-                <h3>{this.props.content}</h3>
-                </ExpansionPanelSummary>
-                <ExpansionPanelDetails>
-                <h4>Match_id:{this.props.match_id}</h4>
+              Delete
+            </Button>
 
-                <Button color='danger' onClick={() => this.props.deleteMeeting(this.props.id)}>
-                    Delete
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={this.handleClickOpen}
+            >
+              Edit
+            </Button>
+
+            <Dialog
+              open={this.state.open}
+              onClose={this.handleClose}
+              aria-labelledby="form-dialog-title"
+            >
+              <DialogContent>
+                <MeetingsForm
+                  canEdit={true}
+                  id={this.props.id}
+                  content={this.props.content}
+                />
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={this.handleClose} color="primary">
+                  Cancel
                 </Button>
-                <Button color='warning' onClick={this.toggle}>
-                    Edit
-                </Button>
-                <Modal
-                    isOpen={this.state.modal}
-                    toggle={this.toggle}
-                    className={this.props.className}
-                    external={externalCloseBtn}
-                >
-                    <ModalBody>
-                        <MeetingsForm
-                            canEdit={true}
-                            id={this.props.id}
-                            content={this.props.content}
-                        />
-                    </ModalBody>
-                </Modal>
-                </ExpansionPanelDetails>
-                </ExpansionPanel>
-            </div>
-        );
-    }
+              </DialogActions>
+            </Dialog>
+          </ExpansionPanelDetails>
+        </ExpansionPanel>
+      </div>
+    );
+  }
 }
 
-const mapStateToProps = (state) => {
-    return {};
+const mapStateToProps = state => {
+  return {};
 };
 
 const mapDispatchToProps = {
-    deleteMeeting
+  deleteMeeting
 };
 
 export default connect(
-    mapStateToProps,
-    mapDispatchToProps
+  mapStateToProps,
+  mapDispatchToProps
 )(withStyles(styles)(MeetingCard));

--- a/src/components/MeetingsComponents/MeetingsList.js
+++ b/src/components/MeetingsComponents/MeetingsList.js
@@ -26,7 +26,8 @@ class MeetingsList extends React.Component {
     super(props);
     this.state = {
       modal: false,
-      isLoaded: false
+      isLoaded: false,
+      open: false
     };
 
     this.toggle = this.toggle.bind(this);
@@ -41,6 +42,14 @@ class MeetingsList extends React.Component {
     await this.props.getMeetings();
     this.setState({ ...this.state, isLoaded: true });
   }
+
+  handleClickOpen = () => {
+    this.setState({ open: true });
+  };
+
+  handleClose = () => {
+    this.setState({ open: false });
+  };
 
   render() {
     const externalCloseBtn = (

--- a/src/components/MeetingsComponents/MeetingsList.js
+++ b/src/components/MeetingsComponents/MeetingsList.js
@@ -3,24 +3,24 @@ import { connect } from "react-redux";
 import { getMeetings } from "../../actions";
 import MeetingsForm from "./MeetingsForm";
 import MeetingCard from "./MeetingCard";
-import styled from 'styled-components';
+import styled from "styled-components";
 import MaterialSideBar from "../MaterialSideBar";
-import Button from '@material-ui/core/Button';
-import Dialog from '@material-ui/core/Dialog';
-import DialogActions from '@material-ui/core/DialogActions';
-import DialogContent from '@material-ui/core/DialogContent';
+import Button from "@material-ui/core/Button";
+import Dialog from "@material-ui/core/Dialog";
+import DialogActions from "@material-ui/core/DialogActions";
+import DialogContent from "@material-ui/core/DialogContent";
 
 const ContainerDiv = styled.div`
-    display: flex;
-    flex-direction: row;
-    width: 100%;
-    height: 100%;
-    padding: 10px;
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  height: 100%;
+  padding: 10px;
 `;
 
 const MeetingContainer = styled.div`
-    width: 70%;
-    margin: auto;
+  width: 70%;
+  margin: auto;
 `;
 
 class MeetingsList extends React.Component {
@@ -53,61 +53,58 @@ class MeetingsList extends React.Component {
   };
 
   render() {
-
-
     const nonDeleted = this.props.meetings.filter(meeting => {
       return meeting.deleted === false;
     });
-    
+
     return (
       <div>
         <h1>Your Meetings</h1>
-          <ContainerDiv>
+        <ContainerDiv>
           <MaterialSideBar />
           <MeetingContainer>
-          <h2>Upcoming Meetings</h2>
-          <Button variant="outlined" color="primary" onClick={this.handleClickOpen}>
-          Create New Meeting
-        </Button>
-
-          <Dialog
-          open={this.state.open}
-          onClose={this.handleClose}
-          aria-labelledby="form-dialog-title"
-        >
-          <DialogContent>
-          <MeetingsForm canEdit={false} />
-          </DialogContent>
-          <DialogActions>
-            <Button onClick={this.handleClose} color="primary">
-              Cancel
+            <h2>Upcoming Meetings</h2>
+            <Button
+              variant="outlined"
+              color="primary"
+              onClick={this.handleClickOpen}
+            >
+              Create New Meeting
             </Button>
-          </DialogActions>
-        </Dialog>
 
-          {this.state.isLoaded ? (
-            nonDeleted.map((meeting, index) => {
-              return (
-                <div key={index}>
-                  
-                  <MeetingCard
-                    id={meeting.id}
-                    content={meeting.content}
-                    match_id={meeting.match_id}
-                    deleteMeeting={this.props.deleteMeeting}
-                  />
-                </div>
-              );
-            })
-          ) : (
-            <h3>Loading</h3>
-          )}
+            <Dialog
+              open={this.state.open}
+              onClose={this.handleClose}
+              aria-labelledby="form-dialog-title"
+            >
+              <DialogContent>
+                <MeetingsForm canEdit={false} />
+              </DialogContent>
+              <DialogActions>
+                <Button onClick={this.handleClose} color="primary">
+                  Cancel
+                </Button>
+              </DialogActions>
+            </Dialog>
 
+            {this.state.isLoaded ? (
+              nonDeleted.map((meeting, index) => {
+                return (
+                  <div key={index}>
+                    <MeetingCard
+                      id={meeting.id}
+                      content={meeting.content}
+                      match_id={meeting.match_id}
+                      deleteMeeting={this.props.deleteMeeting}
+                    />
+                  </div>
+                );
+              })
+            ) : (
+              <h3>Loading</h3>
+            )}
 
-
-
-          <h2>Past Meetings</h2>
-          
+            <h2>Past Meetings</h2>
           </MeetingContainer>
         </ContainerDiv>
       </div>

--- a/src/components/MeetingsComponents/MeetingsList.js
+++ b/src/components/MeetingsComponents/MeetingsList.js
@@ -1,13 +1,14 @@
 import React from "react";
-import { Link } from "react-router-dom";
 import { connect } from "react-redux";
 import { getMeetings } from "../../actions";
-import { Button, Modal, ModalBody } from "reactstrap";
 import MeetingsForm from "./MeetingsForm";
 import MeetingCard from "./MeetingCard";
 import styled from 'styled-components';
-import Sidebar from '../Sidebar';
 import MaterialSideBar from "../MaterialSideBar";
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
 
 const ContainerDiv = styled.div`
     display: flex;
@@ -26,7 +27,6 @@ class MeetingsList extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      modal: false,
       isLoaded: false,
       open: false
     };
@@ -53,15 +53,7 @@ class MeetingsList extends React.Component {
   };
 
   render() {
-    const externalCloseBtn = (
-      <button
-        className="close"
-        style={{ position: "absolute", top: "15px", right: "15px" }}
-        onClick={this.toggle}
-      >
-        &times;
-      </button>
-    );
+
 
     const nonDeleted = this.props.meetings.filter(meeting => {
       return meeting.deleted === false;
@@ -74,9 +66,25 @@ class MeetingsList extends React.Component {
           <MaterialSideBar />
           <MeetingContainer>
           <h2>Upcoming Meetings</h2>
-          <Button color="primary" onClick={this.toggle}>
-            Create New Meeting
-          </Button>
+          <Button variant="outlined" color="primary" onClick={this.handleClickOpen}>
+          Create New Meeting
+        </Button>
+
+          <Dialog
+          open={this.state.open}
+          onClose={this.handleClose}
+          aria-labelledby="form-dialog-title"
+        >
+          <DialogContent>
+          <MeetingsForm canEdit={false} />
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleClose} color="primary">
+              Cancel
+            </Button>
+          </DialogActions>
+        </Dialog>
+
           {this.state.isLoaded ? (
             nonDeleted.map((meeting, index) => {
               return (
@@ -96,16 +104,7 @@ class MeetingsList extends React.Component {
           )}
 
 
-          <Modal
-            isOpen={this.state.modal}
-            toggle={this.toggle}
-            className={this.props.className}
-            external={externalCloseBtn}
-          >
-            <ModalBody>
-              <MeetingsForm canEdit={false} />
-            </ModalBody>
-          </Modal>
+
 
           <h2>Past Meetings</h2>
           

--- a/src/pages/UserProfile.js
+++ b/src/pages/UserProfile.js
@@ -1,20 +1,5 @@
 import React from "react";
-import {
-  Form,
-  FormGroup,
-  Label,
-  Input,
-  Col,
-  Row,
-  Card,
-  CardBody,
-  TabContent,
-  TabPane,
-  Nav,
-  NavItem,
-  NavLink,
-  Button
-} from "reactstrap";
+import { Form, FormGroup, Label, Col, Row, Card, CardBody } from "reactstrap";
 import classnames from "classnames";
 import { connect } from "react-redux";
 import history from "../history";
@@ -22,7 +7,6 @@ import { getCurrentUser } from "../actions/auth";
 import ExperienceList from "../components/ExperiencesComponents/ExperienceList";
 import MeetingsList from "../components/MeetingsComponents/MeetingsList";
 import UserProfileForm from "../components/UserComponents/UserProfileForm";
-import Sidebar from "../components/Sidebar";
 import MaterialSideBar from "../components/MaterialSideBar";
 import styled from "styled-components";
 import MentorsList from "../components/MentorComponents/MentorsList.js";
@@ -33,6 +17,8 @@ import AppBar from "@material-ui/core/AppBar";
 import Tabs from "@material-ui/core/Tabs";
 import Tab from "@material-ui/core/Tab";
 import Typography from "@material-ui/core/Typography";
+import Avatar from "@material-ui/core/Avatar";
+import Grid from "@material-ui/core/Grid";
 
 function TabContainer(props) {
   return (
@@ -49,6 +35,14 @@ TabContainer.propTypes = {
 const styles = {
   root: {
     flexGrow: 1
+  },
+  avatar: {
+    margin: 10
+  },
+  bigAvatar: {
+    margin: 10,
+    width: 60,
+    height: 60
   }
 };
 
@@ -154,6 +148,7 @@ class UserProfile extends React.Component {
               <Tab label="USER UPDATE" />
             </Tabs>
           </AppBar>
+
           {value === 0 && (
             <TabContainer>
               <ContainerDiv>
@@ -246,153 +241,6 @@ class UserProfile extends React.Component {
             </TabContainer>
           )}
         </div>
-        // <div>
-        //   <Nav tabs>
-        //     <NavItem>
-        //       <NavLink
-        //         className={classnames({ active: this.state.activeTab === "1" })}
-        //         onClick={() => {
-        //           this.toggle("1");
-        //         }}
-        //       >
-        //         Profile Information
-        //       </NavLink>
-        //     </NavItem>
-        //     <NavItem>
-        //       <NavLink
-        //         className={classnames({ active: this.state.activeTab === "2" })}
-        //         onClick={() => {
-        //           this.toggle("2");
-        //         }}
-        //       >
-        //         Meetings
-        //       </NavLink>
-        //     </NavItem>
-        //     <NavItem>
-        //       <NavLink
-        //         className={classnames({ active: this.state.activeTab === "3" })}
-        //         onClick={() => {
-        //           this.toggle("3");
-        //         }}
-        //       >
-        //         Mentors
-        //       </NavLink>
-        //     </NavItem>
-        //     <NavItem>
-        //       <NavLink
-        //         className={classnames({ active: this.state.activeTab === "4" })}
-        //         onClick={() => {
-        //           this.toggle("4");
-        //         }}
-        //       >
-        //         Update User
-        //       </NavLink>
-        //     </NavItem>
-        //   </Nav>
-        //   <TabContent activeTab={this.state.activeTab}>
-        //     <TabPane tabId="1">
-        //       <Row>
-        //         <Col sm="12">
-        //           <ContainerDiv>
-        //             <Sidebar />
-        //             <ProfileContainer>
-        //               <Form>
-        //                 <Row>
-        //                   <Col md={6}>
-        //                     <FormGroup>
-        //                       <h3>First Name</h3>
-        //                       <Label for="lastName">
-        //                         {this.state.user.first_name}
-        //                       </Label>
-        //                     </FormGroup>
-        //                   </Col>
-
-        //                   <Col md={6}>
-        //                     <FormGroup>
-        //                       <h3>Last Name</h3>
-        //                       <Label for="lastName">
-        //                         {this.state.user.last_name}
-        //                       </Label>
-        //                     </FormGroup>
-        //                   </Col>
-        //                 </Row>
-
-        //                 <Row>
-        //                   <Col md={6}>
-        //                     <FormGroup>
-        //                       <h3>State</h3>
-
-        //                       <Label for="address">
-        //                         {this.state.user.state}
-        //                       </Label>
-        //                     </FormGroup>
-        //                   </Col>
-
-        //                   <Col md={6}>
-        //                     <FormGroup>
-        //                       <h3>Street</h3>
-
-        //                       <Label for="zipCode">
-        //                         {this.state.user.street}
-        //                       </Label>
-        //                     </FormGroup>
-        //                   </Col>
-        //                 </Row>
-
-        //                 <Row>
-        //                   <Col md={6}>
-        //                     <FormGroup>
-        //                       <Label for="github">Github</Label>
-        //                       <Input
-        //                         type="text"
-        //                         name="github"
-        //                         id="github"
-        //                         value={this.state.github}
-        //                         onChange={this.changeHandler}
-        //                       />
-        //                     </FormGroup>
-        //                   </Col>
-
-        //                   <Col md={6}>
-        //                     <FormGroup>
-        //                       <Label for="linkedIn">linkedIn</Label>
-        //                       <Input
-        //                         type="text"
-        //                         name="linkedIn"
-        //                         id="linkedIn"
-        //                         value={this.state.linkedIn}
-        //                         onChange={this.changeHandler}
-        //                       />
-        //                     </FormGroup>
-        //                   </Col>
-        //                 </Row>
-
-        //                 <Card>
-        //                   <CardBody>
-        //                     <ExperienceList />
-        //                   </CardBody>
-        //                 </Card>
-        //               </Form>
-        //             </ProfileContainer>
-        //           </ContainerDiv>
-        //         </Col>
-        //       </Row>
-        //     </TabPane>
-        //     <TabPane tabId="2">
-        //       <MeetingsList />
-        //     </TabPane>
-        //     <TabPane tabId="3">
-        //       {this.state.applied ? (
-        //         <h2>Applied</h2>
-        //       ) : (
-        //         <MentorsList userId={this.state.user.id} />
-        //       )}
-        //     </TabPane>
-        //     <TabPane tabId="4">
-        //       <UserProfileForm />
-        //     </TabPane>
-        //   </TabContent>
-        // </div>
       );
     }
   }
@@ -400,7 +248,8 @@ class UserProfile extends React.Component {
 
 UserProfile.propTypes = {
   user: PropTypes.object.isRequired,
-  mentees: PropTypes.array.isRequired
+  mentees: PropTypes.array.isRequired,
+  classes: PropTypes.object.isRequired
 };
 
 const mapStateToProps = state => {
@@ -421,4 +270,4 @@ const mapDispatchToProps = {
 export default connect(
   mapStateToProps,
   mapDispatchToProps
-)(UserProfile);
+)(withStyles(styles)(UserProfile));


### PR DESCRIPTION
# Description

MAterial ui components imported in meetings list and meetings card as well as experience. Trying to make list into scrollable components and finish up text to material ui

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## Change status
- [x] Complete, tested, ready to review and merge


# How Has This Been Tested?

local host tested

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts